### PR TITLE
Fix JQMIGRATE: jQuery.fn.blur() event shorthand is deprecated

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,4 @@
 os: linux
-dist: trusty
 
 cache:
   directories:
@@ -27,7 +26,7 @@ env:
     - WORDPRESS_DB_USER=wp
     - WORDPRESS_DB_PASS=password
     - WORDPRESS_DB_NAME=wp_tests
-    - WP_VERSION=5.5.1
+    - WP_VERSION=5.6.1
     - WP_MULTISITE=0
 
 install:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,9 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 
 # UNRELEASED
 
+## 2020-10-06 (README and composer.json update)
+- Add suggestion for `frontpack/composer-assets-plugin`.
+
 ## 3.2.2 - 2020-09-16
 - Version bump since composer didn't pick up 3.2.1.
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,9 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 
 # UNRELEASED
 
+## 3.2.3 - 2021-02-07
+- Fix: JQMIGRATE: jQuery.fn.blur() event shorthand is deprecated #23.
+
 ## 2020-10-06 (README and composer.json update)
 - Add suggestion for `frontpack/composer-assets-plugin`.
 

--- a/README.md
+++ b/README.md
@@ -39,102 +39,119 @@ In order to have the settings page inherit the styles and use the proper JS, you
 directory:
 
 ```php
-// ASSUME THIS IS IN A CLASS....
+<?php declare(strict_types=1);
+
+namespace Vendor\Package;
 
 use Dwnload\WpSettingsApi\Api\Script;
 use Dwnload\WpSettingsApi\Api\Style;
 use Dwnload\WpSettingsApi\WpSettingsApi;
-
-\add_filter(WpSettingsApi::FILTER_PREFIX . 'admin_scripts', [$this, 'adminScripts']);
-\add_filter(WpSettingsApi::FILTER_PREFIX . 'admin_styles', [$this, 'adminStyles']);
-
-/**
- * The default script needs to be moved from the vendor directory somewhere into our app since the
- * vendor directory is outside of the doc root.
- * @param Script[] $scripts
- * @return array
- */
-public function adminScripts(array $scripts): array
-{
-    \array_walk($scripts, function (Script $script, int $key) use (&$scripts) {
-        switch ($script->getHandle()) {
-            case WpSettingsApi::ADMIN_SCRIPT_HANDLE:
-            /**
-             * If you're not using the `TheFrosty\WpUtilities\Plugin\AbstractHookProvider`
-             * use `plugins_url()` in place of the `$this->getPlugin()->getUrl` or any other WP
-             * function that will point to the asset.
-             * (Should match `frontpack/composer-assets-plugin configs`)
-             */
-            $scripts[$key]->setSrc($this->getPlugin()->getUrl('assets/js/admin.js'));
-            break;
-        case WpSettingsApi::ADMIN_MEDIA_HANDLE:
-            /**
-             * If you're not using the `TheFrosty\WpUtilities\Plugin\AbstractHookProvider`
-             * use `plugins_url()` in place of the `$this->getPlugin()->getUrl` or any other WP
-             * function that will point to the asset.
-             * (Should match `frontpack/composer-assets-plugin configs`)
-             */
-            $scripts[$key]->setSrc($this->getPlugin()->getUrl('assets/js/wp-media-uploader.js'));
-            break;
-        }
-        $this->registerScript($script);
-    });
-
-    return $scripts;
-}
+use TheFrosty\WpUtilities\Plugin\AbstractHookProvider;
+use TheFrosty\WpUtilities\Plugin\HooksTrait;
 
 /**
- * The default style needs to be moved from the vendor directory somewhere into our app since the
- * vendor directory is outside of the doc root.
- * @param Style[] $styles
- * @return array
+ * Class WpSettingsApi
+ *
+ * @package Dwnload\WpSettingsApi
  */
-public function adminStyles(array $styles): array
+class WpSettingsApiScripts extends AbstractHookProvider
 {
-    \array_walk($styles, function (Style $style, int $key) use (&$styles) {
-        if ($style->getHandle() === WpSettingsApi::ADMIN_STYLE_HANDLE) {
-            /**
-             * If you're not using the `TheFrosty\WpUtilities\Plugin\AbstractHookProvider`
-             * use `plugins_url()` in place of the `$this->getPlugin()->getUrl` or any other WP
-             * function that will point to the asset.
-             */
-            $styles[$key]->setSrc($this->getPlugin()->getUrl('assets/css/admin.css'));
-            $this->registerStyle($style);
-        }
-    });
 
-    return $styles;
-}
 
-/**
- * If the script is not registered before being returned back to the filter the src still uses
- * the vendor directory file path.
- * @param Script $script
- */
-private function registerScript(Script $script)
-{
-    \wp_register_script(
-        $script->getHandle(),
-        $script->getSrc(),
-        $script->getDependencies(),
-        $script->getVersion(),
-        $script->getInFooter()
-    );
-}
-
-/**
- * If the style is not registered before being returned back to the filter the src still uses
- * the vendor directory file path.
- * @param Style $style
- */
-private function registerStyle(Style $style)
-{
-    \wp_register_style(
-        $style->getHandle(),
-        $style->getSrc(),
-        $style->getDependencies(),
-        $style->getVersion(),
-        $style->getMedia()
-    );
+    public function addHooks(array $scripts): void
+    {
+        \add_filter(WpSettingsApi::FILTER_PREFIX . 'admin_scripts', [$this, 'adminScripts']);
+        \add_filter(WpSettingsApi::FILTER_PREFIX . 'admin_styles', [$this, 'adminStyles']);
+    }
+    
+    /**
+     * The default script needs to be moved from the vendor directory somewhere into our app since the
+     * vendor directory is outside of the doc root.
+     * @param Script[] $scripts
+     * @return array
+     */
+    public function adminScripts(array $scripts): array
+    {
+        \array_walk($scripts, function (Script $script, int $key) use (&$scripts) {
+            switch ($script->getHandle()) {
+                case WpSettingsApi::ADMIN_SCRIPT_HANDLE:
+                /**
+                 * If you're not using the `TheFrosty\WpUtilities\Plugin\AbstractHookProvider`
+                 * use `plugins_url()` in place of the `$this->getPlugin()->getUrl` or any other WP
+                 * function that will point to the asset.
+                 * (Should match `frontpack/composer-assets-plugin configs`)
+                 */
+                $scripts[$key]->setSrc($this->getPlugin()->getUrl('assets/js/admin.js'));
+                break;
+            case WpSettingsApi::ADMIN_MEDIA_HANDLE:
+                /**
+                 * If you're not using the `TheFrosty\WpUtilities\Plugin\AbstractHookProvider`
+                 * use `plugins_url()` in place of the `$this->getPlugin()->getUrl` or any other WP
+                 * function that will point to the asset.
+                 * (Should match `frontpack/composer-assets-plugin configs`)
+                 */
+                $scripts[$key]->setSrc($this->getPlugin()->getUrl('assets/js/wp-media-uploader.js'));
+                break;
+            }
+            $this->registerScript($script);
+        });
+    
+        return $scripts;
+    }
+    
+    /**
+     * The default style needs to be moved from the vendor directory somewhere into our app since the
+     * vendor directory is outside of the doc root.
+     * @param Style[] $styles
+     * @return array
+     */
+    public function adminStyles(array $styles): array
+    {
+        \array_walk($styles, function (Style $style, int $key) use (&$styles) {
+            if ($style->getHandle() === WpSettingsApi::ADMIN_STYLE_HANDLE) {
+                /**
+                 * If you're not using the `TheFrosty\WpUtilities\Plugin\AbstractHookProvider`
+                 * use `plugins_url()` in place of the `$this->getPlugin()->getUrl` or any other WP
+                 * function that will point to the asset.
+                 */
+                $styles[$key]->setSrc($this->getPlugin()->getUrl('assets/css/admin.css'));
+                $this->registerStyle($style);
+            }
+        });
+    
+        return $styles;
+    }
+    
+    /**
+     * If the script is not registered before being returned back to the filter the src still uses
+     * the vendor directory file path.
+     * @param Script $script
+     */
+    private function registerScript(Script $script): void
+    {
+        \wp_register_script(
+            $script->getHandle(),
+            $script->getSrc(),
+            $script->getDependencies(),
+            $script->getVersion(),
+            $script->getInFooter()
+        );
+    }
+    
+    /**
+     * If the style is not registered before being returned back to the filter the src still uses
+     * the vendor directory file path.
+     * @param Style $style
+     */
+    private function registerStyle(Style $style): void
+    {
+        \wp_register_style(
+            $style->getHandle(),
+            $style->getSrc(),
+            $style->getDependencies(),
+            $style->getVersion(),
+            $style->getMedia()
+        );
+    }
 }
 ```

--- a/README.md
+++ b/README.md
@@ -29,9 +29,11 @@ Usage Example
 
 @see [examples/Example.php](https://github.com/dwnload/WpSettingsApi/tree/master/examples/Example.php)
 
-##### Known issues
+#### Suggested package
 
-Since this is a PHP package and not a WordPress plugin the assets included can't be loaded properly.
+⭐️ `frontpack/composer-assets-plugin`
+
+**Otherwise**, since this is a PHP package and not a WordPress plugin the assets included can't be loaded properly.
 In order to have the settings page inherit the styles and use the proper JS, you've got to copy the
 `/assets` directory to your plugin or theme. Then add the following to filter the asset src to your
 directory:
@@ -55,24 +57,27 @@ use Dwnload\WpSettingsApi\WpSettingsApi;
 public function adminScripts(array $scripts): array
 {
     \array_walk($scripts, function (Script $script, int $key) use (&$scripts) {
-        if ($script->getHandle() === WpSettingsApi::ADMIN_SCRIPT_HANDLE) {
+        switch ($script->getHandle()) {
+            case WpSettingsApi::ADMIN_SCRIPT_HANDLE:
             /**
              * If you're not using the `TheFrosty\WpUtilities\Plugin\AbstractHookProvider`
              * use `plugins_url()` in place of the `$this->getPlugin()->getUrl` or any other WP
              * function that will point to the asset.
+             * (Should match `frontpack/composer-assets-plugin configs`)
              */
             $scripts[$key]->setSrc($this->getPlugin()->getUrl('assets/js/admin.js'));
-            $this->registerScript($script);
-        }
-        if ($script->getHandle() === WpSettingsApi::ADMIN_MEDIA_HANDLE) {
+            break;
+        case WpSettingsApi::ADMIN_MEDIA_HANDLE:
             /**
              * If you're not using the `TheFrosty\WpUtilities\Plugin\AbstractHookProvider`
              * use `plugins_url()` in place of the `$this->getPlugin()->getUrl` or any other WP
              * function that will point to the asset.
+             * (Should match `frontpack/composer-assets-plugin configs`)
              */
             $scripts[$key]->setSrc($this->getPlugin()->getUrl('assets/js/wp-media-uploader.js'));
-            $this->registerScript($script);
+            break;
         }
+        $this->registerScript($script);
     });
 
     return $scripts;

--- a/composer.json
+++ b/composer.json
@@ -1,7 +1,7 @@
 {
   "name": "dwnload/wp-settings-api",
   "description": "A PHP class abstraction that removes all the headaches of the WordPress settings API under the hood and builds a nice options panel on the fly.",
-  "version": "3.2.2",
+  "version": "3.2.3",
   "license": "MIT",
   "authors": [
     {

--- a/composer.json
+++ b/composer.json
@@ -34,6 +34,9 @@
     "squizlabs/php_codesniffer": "^3.2",
     "wp-phpunit/wp-phpunit": "^5.5.1"
   },
+  "suggest": {
+    "frontpack/composer-assets-plugin": "Composer plugin for copying of frontend assets into public directory."
+  },
   "scripts": {
     "install-codestandards": [
       "Dealerdirect\\Composer\\Plugin\\Installers\\PHPCodeSniffer\\Plugin::run"

--- a/src/WpSettingsApi.php
+++ b/src/WpSettingsApi.php
@@ -28,7 +28,7 @@ class WpSettingsApi extends AbstractHookProvider
     public const FILTER_PREFIX = 'dwnload/wp_settings_api/';
     public const ACTION_PREFIX = self::FILTER_PREFIX;
     public const HOOK_PRIORITY = 999;
-    public const VERSION = '3.2.2';
+    public const VERSION = '3.2.3';
 
     /**
      * The current plugin instance.

--- a/src/assets/js/admin.js
+++ b/src/assets/js/admin.js
@@ -1,8 +1,8 @@
-/* global jQuery **/
+/** global jQuery **/
 (function ($) {
   'use strict'
 
-  let Dwnload_WP_Settings = {
+  const WpSettingsApi = {
     localStorageItemId: 'activeTab',
     objects: {
       container: $('.Dwnload_WP_Settings_Api__container'),
@@ -17,13 +17,12 @@
      */
     init: function () {
       this.initUIBindings()
-      this.submitListener()
     },
 
     initUIBindings: function () {
       this.objects.group.hide()
-      this.showActiveMenuItem(Dwnload_WP_Settings.getActiveTab())
-      this.showActiveForm(Dwnload_WP_Settings.getActiveTab())
+      this.showActiveMenuItem(WpSettingsApi.getActiveTab())
+      this.showActiveForm(WpSettingsApi.getActiveTab())
       this.menuItemListener()
       $(function () {
         $('.FieldType_color input').wpColorPicker()
@@ -37,10 +36,10 @@
      * @param {string} activeTab
      */
     showActiveMenuItem: function (activeTab) {
-      if (activeTab !== '' && Dwnload_WP_Settings.objects.menu.find('[data-tab-id="' + activeTab + '"]').length) {
-        Dwnload_WP_Settings.objects.menu.find('[data-tab-id="' + activeTab + '"]').addClass('active')
+      if (activeTab !== '' && WpSettingsApi.objects.menu.find('[data-tab-id="' + activeTab + '"]').length) {
+        WpSettingsApi.objects.menu.find('[data-tab-id="' + activeTab + '"]').addClass('active')
       } else {
-        Dwnload_WP_Settings.objects.menu.find('a').first().addClass('active')
+        WpSettingsApi.objects.menu.find('a').first().addClass('active')
       }
     },
 
@@ -51,12 +50,12 @@
      * @param {string} activeTab
      */
     showActiveForm: function (activeTab) {
-      let activeTabFormObject = Dwnload_WP_Settings.getActiveFormObject(activeTab)
+      const activeTabFormObject = WpSettingsApi.getActiveFormObject(activeTab)
 
       if (activeTab !== '' && activeTabFormObject.length) {
         activeTabFormObject.fadeIn('fast')
       } else {
-        Dwnload_WP_Settings.objects.group.first().fadeIn()
+        WpSettingsApi.objects.group.first().fadeIn()
       }
     },
 
@@ -65,15 +64,15 @@
      * localStorage events.
      */
     menuItemListener: function () {
-      Dwnload_WP_Settings.objects.menu.find('a[data-tab-id]').on('click', function (e) {
-        let clickedGroup = $(this).data('tab-id')
+      WpSettingsApi.objects.menu.find('a[data-tab-id]').on('click', function (e) {
+        const clickedGroup = $(this).data('tab-id')
 
-        Dwnload_WP_Settings.objects.menu.find('a').removeClass('active')
-        $(this).addClass('active').blur()
+        WpSettingsApi.objects.menu.find('a').removeClass('active')
+        $(this).addClass('active').trigger('blur')
 
-        Dwnload_WP_Settings.setActiveTab(clickedGroup)
-        Dwnload_WP_Settings.objects.group.hide()
-        Dwnload_WP_Settings.getActiveFormObject(clickedGroup).fadeIn('fast')
+        WpSettingsApi.setActiveTab(clickedGroup)
+        WpSettingsApi.objects.group.hide()
+        WpSettingsApi.getActiveFormObject(clickedGroup).fadeIn('fast')
         e.preventDefault()
       })
     },
@@ -85,7 +84,7 @@
      */
     setActiveTab: function (id) {
       if (typeof (localStorage) !== 'undefined') {
-        localStorage.setItem(Dwnload_WP_Settings.localStorageItemId, id)
+        localStorage.setItem(WpSettingsApi.localStorageItemId, id)
       }
     },
 
@@ -98,7 +97,7 @@
       let activeTab
 
       if (typeof (localStorage) !== 'undefined') {
-        activeTab = localStorage.getItem(Dwnload_WP_Settings.localStorageItemId)
+        activeTab = localStorage.getItem(WpSettingsApi.localStorageItemId)
       }
 
       return activeTab !== null ? activeTab : ''
@@ -112,23 +111,8 @@
      */
     getActiveFormObject: function (id) {
       return $('#' + id)
-    },
-
-    /**
-     * @todo listen for save all forms submit button to trigger AJAX save all.
-     */
-    submitListener: function () {
-      $(document.body).on('click', '.Dwnload_WP_Settings_Api__group input[type="submit"]', function () {
-        //let group = Dwnload_WP_Settings.objects.group,
-        //  form;
-        //
-        //form = group.is(':visible').find('form');
-        //$(this).attr('form', form.attr('id'));
-        //form.submit();
-      }) //*/
     }
   }
 
-  $(document).ready(Dwnload_WP_Settings.init())
-
+  $(document).ready(WpSettingsApi.init())
 }(jQuery))

--- a/src/assets/js/wp-media-uploader.js
+++ b/src/assets/js/wp-media-uploader.js
@@ -24,12 +24,4 @@
       button.prev().val(attachment.url)
     }).open()
   })
-
-  // Remove button click
-  // $body.on('click', '.misha-rmv', function (e) {
-  //   e.preventDefault()
-  //   let button = $(this)
-  //   button.next().val('') // emptying the hidden field
-  //   button.hide().prev().html('Upload image')
-  // })
 })(jQuery)


### PR DESCRIPTION
Fixes #23 