### PR TITLE
Version 3.3

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -26,7 +26,7 @@ env:
     - WORDPRESS_DB_USER=wp
     - WORDPRESS_DB_PASS=password
     - WORDPRESS_DB_NAME=wp_tests
-    - WP_VERSION=5.6.1
+    - WP_VERSION=5.7.0
     - WP_MULTISITE=0
 
 install:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,11 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 
 # UNRELEASED
 
+## 3.3 - 2021-04-05
+- Add field type: `multiselect`, use `Dwnload\WpSettingsApi\Settings\FieldTypes::FIELD_TYPE_MULTISELECT`.
+- Add missing "attributes" constant: `Dwnload\WpSettingsApi\Settings\FieldTypes\SettingField::ATTRIBUTES`.
+- Update composer development dependencies.
+
 ## 3.2.3 - 2021-02-07
 - Fix: JQMIGRATE: jQuery.fn.blur() event shorthand is deprecated #23.
 

--- a/composer.json
+++ b/composer.json
@@ -1,7 +1,6 @@
 {
   "name": "dwnload/wp-settings-api",
   "description": "A PHP class abstraction that removes all the headaches of the WordPress settings API under the hood and builds a nice options panel on the fly.",
-  "version": "3.2.3",
   "license": "MIT",
   "authors": [
     {
@@ -23,16 +22,16 @@
     "thefrosty/wp-utilities": "^2.0"
   },
   "require-dev": {
-    "dealerdirect/phpcodesniffer-composer-installer": "^0.4.3",
-    "inpsyde/php-coding-standards": "^0.13.4",
+    "dealerdirect/phpcodesniffer-composer-installer": "^0.7",
+    "inpsyde/php-coding-standards": "1.0.0-RC1",
     "phpunit/php-code-coverage": "^6",
     "phpcompatibility/php-compatibility": "*",
     "phpunit/phpunit": "^7",
     "roave/security-advisories": "dev-master",
-    "roots/wordpress": "^5.5.1",
+    "roots/wordpress": "~5.7.0",
     "slevomat/coding-standard": "~4.0",
     "squizlabs/php_codesniffer": "^3.2",
-    "wp-phpunit/wp-phpunit": "^5.5.1"
+    "wp-phpunit/wp-phpunit": "~5.7.0"
   },
   "suggest": {
     "frontpack/composer-assets-plugin": "Composer plugin for copying of frontend assets into public directory."

--- a/phpcs-ruleset.xml
+++ b/phpcs-ruleset.xml
@@ -36,6 +36,14 @@
 
     <rule ref="PSR2"/>
 
+    <rule ref="PSR12">
+        <exclude name="PSR12.Files.FileHeader.IncorrectOrder"/>
+        <exclude name="PSR12.Files.FileHeader.SpacingAfterBlock"/>
+        <exclude name="PSR12.Files.OpenTag.NotAlone"/>
+        <exclude name="PSR12.Traits.UseDeclaration.MultipleImport"/>
+        <exclude name="PSR12.Traits.UseDeclaration.UseAfterBrace"/>
+    </rule>
+
     <!-- Loads the PHP Compatibility ruleset. -->
     <rule ref="PHPCompatibility" />
     <!-- Check for cross-version support for PHP 7.3 and higher. -->

--- a/src/Admin/AdminSettingsPage.php
+++ b/src/Admin/AdminSettingsPage.php
@@ -36,7 +36,7 @@ class AdminSettingsPage
     /**
      * Fire hooks needed on the Settings Page (only).
      */
-    public function load()
+    public function load(): void
     {
         \do_action(WpSettingsApi::ACTION_PREFIX . 'settings_page_loaded');
         $this->addAction('admin_enqueue_scripts', [$this, 'adminEnqueueScripts'], 99);
@@ -46,7 +46,7 @@ class AdminSettingsPage
     /**
      * Enqueue scripts and styles for the Settings page.
      */
-    protected function adminEnqueueScripts()
+    protected function adminEnqueueScripts(): void
     {
         /** WordPress Core */
         if (!\did_action('wp_enqueue_media')) {
@@ -98,7 +98,7 @@ class AdminSettingsPage
     /**
      * Localize PHP objects to pass to any page JS.
      */
-    protected function localizeScripts()
+    protected function localizeScripts(): void
     {
         $localize = new LocalizeScripts();
 
@@ -125,9 +125,8 @@ class AdminSettingsPage
      *
      * @uses wp_register_script()
      */
-    protected function enqueueScripts(array $scripts)
+    protected function enqueueScripts(array $scripts): void
     {
-        /** @var Script $script */
         foreach ($scripts as $script) {
             if (!\wp_script_is($script->getHandle(), 'registered')) {
                 \wp_register_script(
@@ -154,9 +153,8 @@ class AdminSettingsPage
      *
      * @uses wp_register_style()
      */
-    protected function enqueueStyles(array $styles)
+    protected function enqueueStyles(array $styles): void
     {
-        /** @var Style $style */
         foreach ($styles as $style) {
             if (!\wp_style_is($style->getHandle(), 'registered')) {
                 \wp_register_style(
@@ -177,7 +175,7 @@ class AdminSettingsPage
      * Add an inline script.
      * @param Script $script
      */
-    private function addInlineScript(Script $script)
+    private function addInlineScript(Script $script): void
     {
         if (!empty($script->getInlineScript())) {
             \wp_add_inline_script($script->getHandle(), $script->getInlineScript());

--- a/src/Api/LocalizeScripts.php
+++ b/src/Api/LocalizeScripts.php
@@ -26,7 +26,7 @@ class LocalizeScripts
      */
     public function add(string $key, string $value)
     {
-        self::$vars[$key] = \html_entity_decode((string)$value, ENT_QUOTES, 'UTF-8');
+        self::$vars[$key] = \html_entity_decode((string)$value, \ENT_QUOTES, 'UTF-8');
     }
 
     /**

--- a/src/Api/SettingField.php
+++ b/src/Api/SettingField.php
@@ -8,25 +8,26 @@ use Dwnload\WpSettingsApi\Settings\FieldTypes;
  * Class SettingField
  *
  * @package Dwnload\WpSettingsApi\Api
- * phpcs:disable Inpsyde.CodeQuality.PropertyPerClassLimit.TooMuchProperties
  */
 class SettingField
 {
     /**
      * Array key values.
+     * phpcs:disable Inpsyde.CodeQuality.PropertyPerClassLimit.TooMuchProperties
      */
-    const ID = 'id';
-    const CLASS_OBJECT = 'class_object';
-    const DEFAULT = 'default';
-    const DESC = 'description';
-    const LABEL = 'label';
-    const NAME = 'name';
-    const OPTIONS = 'options';
-    const SANITIZE = 'sanitize_callback';
-    const SECTION_ID = 'section_id';
-    const SIZE = 'size';
-    const TYPE = 'type';
-    const FIELD_OBJECT = SettingField::class;
+    public const ID = 'id';
+    public const ATTRIBUTES = 'attributes';
+    public const CLASS_OBJECT = 'class_object';
+    public const DEFAULT = 'default';
+    public const DESC = 'description';
+    public const LABEL = 'label';
+    public const NAME = 'name';
+    public const OPTIONS = 'options';
+    public const SANITIZE = 'sanitize_callback';
+    public const SECTION_ID = 'section_id';
+    public const SIZE = 'size';
+    public const TYPE = 'type';
+    public const FIELD_OBJECT = SettingField::class;
 
     /**
      * SettingField constructor.


### PR DESCRIPTION

- Add field type: `multiselect`, use `Dwnload\WpSettingsApi\Settings\FieldTypes::FIELD_TYPE_MULTISELECT`.
- Add missing "attributes" constant: `Dwnload\WpSettingsApi\Settings\FieldTypes\SettingField::ATTRIBUTES`.
- Update composer development dependencies.