### PR TITLE
Remove roave/security-advisories

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -34,7 +34,6 @@
     "phpcompatibility/php-compatibility": "*",
     "phpunit/phpunit": "^9",
     "rector/rector": "^2.0",
-    "roave/security-advisories": "dev-latest",
     "roots/wordpress": "^6.8",
     "slevomat/coding-standard": "~8.18",
     "squizlabs/php_codesniffer": "^3.2",


### PR DESCRIPTION
Because of https://github.com/Roave/SecurityAdvisories/pull/132